### PR TITLE
modified cas response regex to be more robust

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -4,7 +4,7 @@ const request = require('request-promise-native');
 
 const CASre = new RegExp(`<cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>\\s*`
 			 +   `<cas:authentication(Success|Failure)(?:\\s+code='(\\w+)')?>\\s*`
-			 +       `(?:<cas:user>(.*)</cas:user>|(.*))\\s*`
+			 +       `(?:<cas:user>(.*)</cas:user>|(.*))(?:\\s|.)*`
 			 +   `</cas:authentication\\1>\\s*`
 			 + `</cas:serviceResponse>`);
 


### PR DESCRIPTION
I slightly modified your regex to allow for more lines between <cas:user>...</cas:user> and </cas:authentication... Implementing this at my university did not work at first because the cas system returns other parameters upon login such as
~~~bash
</cas:authenticationSuccess>

    <cas:user>...</cas:user>

    <cas:emailAddress>...</cas:emailAddress>

    # etc...

</cas:authenticationSuccess>
~~~
This little change fixed it.